### PR TITLE
Convert mocha convention to yarn on before and after.  Update package…

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "lint": "esw webpack.config.* src buildScripts --color",
     "lint:watch": "npm run lint -- --watch",
     "security-check": "nsp check",
-    "test": "mocha --reporter spec buildScripts/testSetup.js \"src/**/*.test.js\"",
-    "test:watch": "npm run test -- --watch",
+    "test": "run-s test:*",
+    "test:jest": "jest --env=jsdom --coverage --no-colors",
+    "test:jest:watch": "jest  --env=jsdom --no-colors --watch",
     "clean-dist": "rimraf ./dist && mkdir dist",
     "prebuild": "npm-run-all clean-dist test lint",
     "build-define": "build-for-lambda --in src/lambda/DefineAuthChallenge/index.js --name handler --out dist/DefineAuthChallenge.js",
@@ -19,7 +20,8 @@
   "author": "CWDS",
   "license": "MIT",
   "dependencies": {
-    "aws-sdk": "^2.250.1"
+    "aws-sdk": "^2.250.1",
+    "jest": "^23.2.0"
   },
   "devDependencies": {
     "aws-sdk-mock": "^2.0.0",

--- a/src/aws/DeviceTrackingService.js
+++ b/src/aws/DeviceTrackingService.js
@@ -1,9 +1,9 @@
-var AWS = require('aws-sdk');
-var logWrapper = require('../utils/logWrapper');
+const AWS = require('aws-sdk');
+const logWrapper = require('../utils/logWrapper');
 
 exports.track = function(deviceId, event, context, challengeName) {
-  var  dynamo = new AWS.DynamoDB();
-  var eParams = exports.paramsForGetItem(deviceId, event);
+  const  dynamo = new AWS.DynamoDB();
+  const eParams = exports.paramsForGetItem(deviceId, event);
    dynamo.getItem(eParams, function(err, data) {
     if (err) {
         logWrapper.logExceptOnTest(err, err.stack);
@@ -71,7 +71,7 @@ exports.manageNonVerifiedDevice = function(deviceId, event, context) {
   let idp = new AWS.CognitoIdentityServiceProvider({
     region: process.env.COGNITO_REGION
   });
-  var params = exports.paramsForGettingTrackedDevice(deviceId, event);
+  const params = exports.paramsForGettingTrackedDevice(deviceId, event);
 
   idp.adminGetDevice(params, function(err, data) {
      if (err) {
@@ -116,9 +116,9 @@ exports.paramsForGettingTrackedDevice = function(deviceId, event) {
  * @param {*} setResponseAnswerCorrect
  */
 exports.saveDeviceToDynamo = function(deviceId, time, event, context, setResponseAnswerCorrect ) {
-  var  dynamo = new AWS.DynamoDB();
+  const dynamo = new AWS.DynamoDB();
 
-  var params = exports.paramsForStoringTrackedDeviceCounter(deviceId, time, event);
+  const params = exports.paramsForStoringTrackedDeviceCounter(deviceId, time, event);
 
   dynamo.updateItem(params, function(err, data) {
        if (err) {

--- a/src/aws/DeviceTrackingService.test.js
+++ b/src/aws/DeviceTrackingService.test.js
@@ -24,7 +24,7 @@ describe('DeviceTrackingService.js Tests', () => {
   };
 
 
-  before(() => {
+  beforeAll(() => {
     succeed = sinon.fake();
     fail = sinon.fake();
 
@@ -59,7 +59,7 @@ describe('DeviceTrackingService.js Tests', () => {
       let stubManageVerifiedDevice;
       let stubManageNonVerifiedDevice;
 
-      before(() => {
+      beforeAll(() => {
         fakeManageVerifiedDevice = sinon.fake();
         fakeManageNonVerifiedDevice = sinon.fake();
         stubManageVerifiedDevice = sinon.stub(DeviceTrackingService, "manageVerifiedDevice").callsFake(fakeManageVerifiedDevice);
@@ -75,7 +75,7 @@ describe('DeviceTrackingService.js Tests', () => {
       afterEach(() => {
       });
 
-      after(() => {
+      afterAll(() => {
         stubManageVerifiedDevice.restore();
         stubManageNonVerifiedDevice.restore();
       });
@@ -391,7 +391,7 @@ describe('DeviceTrackingService.js Tests', () => {
       let fakeSaveToDynamo;
       let stubSaveToDynamo;
 
-      before(() => {
+      beforeAll(() => {
         fakeSaveToDynamo = sinon.fake();
         stubSaveToDynamo = sinon.stub(DeviceTrackingService, "saveDeviceToDynamo").callsFake(fakeSaveToDynamo);
       });

--- a/src/aws/EmailService.test.js
+++ b/src/aws/EmailService.test.js
@@ -15,7 +15,7 @@ describe('EmailService.js Tests', () => {
   let fakeSesSendMail;
 
 
-  before(() => {
+  beforeAll(() => {
     fakeSesSendMail = sinon.fake();
 
     succeed = sinon.fake();

--- a/src/lambda/CreateAuthChallenge/index.test.js
+++ b/src/lambda/CreateAuthChallenge/index.test.js
@@ -15,7 +15,7 @@ describe('CreateAuthChallenge Tests', () => {
   let sendEmailStub;
 
 
-  before(() => {
+  beforeAll(() => {
     succeed = sinon.fake();
     fail = sinon.fake();
     context = Object.assign({}, baseContext, {succeed: succeed, fail: fail});
@@ -30,7 +30,7 @@ describe('CreateAuthChallenge Tests', () => {
     sendEmailFake.resetHistory();
   });
 
-  after(() => {
+  afterAll(() => {
     sendEmailStub.restore();
   });
 

--- a/src/lambda/DefineAuthChallenge/index.test.js
+++ b/src/lambda/DefineAuthChallenge/index.test.js
@@ -8,7 +8,7 @@ describe('DefineCustomAuth Tests', () => {
   let done;
   let context;
 
-  before(() => {
+  beforeAll(() => {
     done = sinon.fake();
     context = Object.assign({}, baseContext, {done: done})
   });

--- a/src/lambda/VerifyAuthChallenge/index.test.js
+++ b/src/lambda/VerifyAuthChallenge/index.test.js
@@ -14,7 +14,7 @@ describe('VerifyAuthChallenge Tests', () => {
   let stubTrack;
   let context;
 
-  before(() => {
+  beforeAll(() => {
     done = sinon.fake();
     succeed = sinon.fake();
     fail = sinon.fake();
@@ -31,7 +31,7 @@ describe('VerifyAuthChallenge Tests', () => {
     track.resetHistory();
   });
 
-  after(() => {
+  afterAll(() => {
     stubTrack.restore();
   });
 

--- a/src/utils/logWrapper.test.js
+++ b/src/utils/logWrapper.test.js
@@ -7,11 +7,11 @@ describe('logWrapper Tests', () => {
 
   let consoleLogSpy;
 
-  before(() => {
+  beforeAll(() => {
     consoleLogSpy = sinon.spy(console, "log");
   });
 
-  after(() => {
+  afterAll(() => {
     consoleLogSpy.restore();
   });
 


### PR DESCRIPTION
….json

This PR will convert from mocha to jest.  There are a few "const" instead of "var" conversions in here too.

I've tested "yarn test". and "yarn test:jest:watch". and they seem fine now.  Big bonus is seen code coverage when you run tests.