### PR TITLE
CreateAuth updated to set OTP_CHALLENGE in a new case

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,7 @@
   "description": "Cognito funcitons to support custom authentication flow for CWDS-CARES",
   "scripts": {
     "build-define": "build-for-lambda --in src/lambda/DefineAuthChallenge/index.js --name handler --out dist/define/index.js",
-    "aws-sdk-mock": "^4.1.0",
     "build-create": "build-for-lambda --in src/lambda/CreateAuthChallenge/index.js --name handler --out dist/create/index.js",
-    "babel-core": "^6.25.0",
     "build-verify": "build-for-lambda --in src/lambda/VerifyAuthChallenge/index.js --name handler --out dist/verify/index.js",
     "build": "npm-run-all prebuild build-define build-create build-verify",
     "clean-dist": "rimraf ./dist && mkdir dist",

--- a/src/aws/OtpChallengeService.js
+++ b/src/aws/OtpChallengeService.js
@@ -31,7 +31,7 @@ exports.setupOtpChallenge = function(email, event, context) {
             if (event.request.session) {
                 incomingMetadata = event.request.session[event.request.session.length - 1].challengeMetadata;
             }
-            
+
             if (incomingMetadata.startsWith('UNIQUE-KEY')) {
               
                 if (found && found.Value === 't') {


### PR DESCRIPTION
- When `challengeMetadata` is not null and does not begin with `UNIQUE-KEY`, that is a re-attempt of MFA entry and we need to set challenge name `OTP_CHALLENGE`